### PR TITLE
Added missing zlib1g dependency

### DIFF
--- a/JekyllRB/Dockerfile
+++ b/JekyllRB/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     g++ \
     gcc \
     make \
+    zlib1g \
  && rm -rf /var/lib/apt/lists/*
 
 RUN gem install jekyll bundler


### PR DESCRIPTION
Jekyll also requires zlib1g to be able to install and run the
github-pages collection of gems.