### PR TITLE
Pinning Jekyll to GitHub-Pages version

### DIFF
--- a/JekyllRB/Dockerfile
+++ b/JekyllRB/Dockerfile
@@ -4,12 +4,16 @@ RUN apt-get update \
  && apt-get install -y \
     apt-utils \
  && apt-get install -y \
-    ruby \
-    ruby-dev \
+    build-essential \
     g++ \
     gcc \
     make \
+    liblzma-dev \
+    patch \
+    ruby \
+    ruby-dev \
     zlib1g \
+    zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
-RUN gem install jekyll bundler
+RUN gem install jekyll:3.9.0 bundler


### PR DESCRIPTION
GitHub-Pages has a dependency version of 3.9.0 for Jekyll.